### PR TITLE
Add clusterName to status and bump configuration-aws-eks

### DIFF
--- a/apis/pat/composition.yaml
+++ b/apis/pat/composition.yaml
@@ -65,6 +65,9 @@ spec:
               - type: FromCompositeFieldPath
                 fromFieldPath: spec.parameters.serviceAccount.namespace
                 toFieldPath: spec.forProvider.namespace
+              - type: ToCompositeFieldPath
+                fromFieldPath: status.atProvider.clusterName
+                toFieldPath: status.podIdentity.clusterName
 
           - name: iamRole
             base:

--- a/crossplane.yaml
+++ b/crossplane.yaml
@@ -12,4 +12,4 @@ spec:
   dependsOn:
     - configuration: xpkg.upbound.io/upbound/configuration-aws-eks
       # renovate: datasource=github-releases depName=upbound/configuration-aws-eks
-      version: "v0.12.0"
+      version: "v0.13.1"


### PR DESCRIPTION
<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->

Adding `clusterName` in status allows other configurations using it instead of reimplementing it themselves as we already have the logic in this module and as the configuration serves as a way of providing identity it seems like the right place to add.

I have:

- [ ] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->
